### PR TITLE
Prefix validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,6 +249,7 @@ internals.normalizePath = (path, thisRouteOpts) => {
 
     // Deal with prefix option
     if (thisRouteOpts.prefix) {
+        // Prefix pattern copied from hapi's prefix validation
         Hoek.assert(typeof thisRouteOpts.prefix === 'string' && thisRouteOpts.prefix.match(/^\/.+/), 'Prefix parameter should be a string following the pattern: /^\\/.+/');
         path = internals.removePrefixFromPath(path, thisRouteOpts.prefix);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -248,7 +248,10 @@ internals.normalizePath = (path, thisRouteOpts) => {
     }
 
     // Deal with prefix option
-    path = internals.removePrefixFromPath(path, thisRouteOpts.prefix);
+    if (thisRouteOpts.prefix) {
+        Hoek.assert(typeof thisRouteOpts.prefix === 'string' && thisRouteOpts.prefix.match(/^\/.+/), 'Prefix parameter should be a string following the pattern: /^\\/.+/');
+        path = internals.removePrefixFromPath(path, thisRouteOpts.prefix);
+    }
 
     // Deal with user creds options.
     if (thisRouteOpts.actAsUser &&
@@ -314,9 +317,9 @@ internals.pathBeginsWith = (path, needle) => {
 internals.removePrefixFromPath = (path, prefix) => {
 
     Hoek.assert(typeof path === 'string', 'Path parameter should be a string');
-    Hoek.assert(typeof prefix === 'string', 'Prefix parameter should be a string or falsy.');
+    Hoek.assert(typeof prefix === 'string', 'Prefix parameter should be a string');
     // Remove trailing slashes from prefix
     prefix = prefix.replace(/\/+$/, '');
 
-    return path.slice(prefix.length);
+    return path.replace(new RegExp(`^${prefix}`), '');
 };

--- a/test/index.js
+++ b/test/index.js
@@ -83,10 +83,145 @@ describe('Tandy', () => {
 
     });
 
-    /**
-    it('throws when given an invalid prefix');
-    it('replaces prefix only if matched at start of the route')
-    **/
+    it('throws when given an invalid prefix', async () => {
+
+        const config = getOptions({
+            tandy: {
+                // Globally set prefix, invalid URL segment
+                prefix: 'no-leading-slash'
+            }
+        });
+
+        const server = await getServer(config);
+        await server.initialize();
+
+        try {
+            server.route({
+                method: 'GET',
+                path: '/route',
+                handler: { tandy: {} }
+            });
+        }
+        catch (err) {
+            expect(err).to.be.an.error();
+            expect(err).to.be.an.error('Prefix parameter should be a string following the pattern: /^\\/.+/');
+        }
+
+        try {
+            server.route({
+                method: 'GET',
+                path: '/route',
+                handler: {
+                    tandy: {
+                        // Route-specific invalid prefix value
+                        prefix: 5
+                    }
+                }
+            });
+        }
+        catch (err) {
+            expect(err).to.be.an.error();
+            expect(err).to.be.an.error('Prefix parameter should be a string following the pattern: /^\\/.+/');
+        }
+    });
+
+    it('replaces prefix if found at the start of the given route\'s path', async () => {
+
+        const config = getOptions({
+            schwifty: {
+                models: [
+                    TestModels.Users,
+                    TestModels.Tokens
+                ]
+            },
+            tandy: {
+                prefix: '/prefix'
+            }
+        });
+
+        const server = await getServer(config);
+        await server.initialize();
+
+        try {
+            server.route({
+                method: 'POST',
+                path: '/users/prefix',
+                config: {
+                    description: 'Register new user',
+                    validate: {
+                        payload: {
+                            email: Joi.string().email().required(),
+                            password: Joi.string().required(),
+                            firstName: Joi.string().required(),
+                            lastName: Joi.string().required()
+                        }
+                    },
+                    auth: false
+                },
+                handler: { tandy: {} }
+            });
+        }
+        catch (err) {
+            expect(err).to.be.an.error();
+            // Signifies prefix was failed to be removed, so path was misinterpreted
+            expect(err).to.be.an.error('This post route does not match a Tandy pattern.');
+        }
+    });
+
+    it('strips the given prefix only if an exact match at the start of the route path', async () => {
+
+        const config = getOptions({
+            schwifty: {
+                models: [
+                    TestModels.Users,
+                    TestModels.Tokens
+                ]
+            },
+            tandy: {
+                prefix: '/prefix'
+            }
+        });
+
+        const server = await getServer(config);
+        await server.initialize();
+
+        server.route({
+            method: 'POST',
+            path: '/prefix/users',
+            config: {
+                description: 'Register new user',
+                validate: {
+                    payload: {
+                        email: Joi.string().email().required(),
+                        password: Joi.string().required(),
+                        firstName: Joi.string().required(),
+                        lastName: Joi.string().required()
+                    }
+                },
+                auth: false
+            },
+            handler: { tandy: {} }
+        });
+
+        const options = {
+            method: 'POST',
+            url: '/prefix/users',
+            payload: {
+                email: 'test@test.com',
+                password: 'password',
+                firstName: 'Test',
+                lastName: 'Test'
+            }
+        };
+
+        const res = await server.inject(options);
+
+        const result = res.result;
+
+        expect(res.statusCode).to.equal(201);
+        expect(result).to.be.an.object();
+        expect(result.email).to.equal('test@test.com');
+    });
 
     it('creates a new user', async () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,11 @@ describe('Tandy', () => {
 
     });
 
+    /**
+    it('throws when given an invalid prefix');
+    it('replaces prefix only if matched at start of the route')
+    **/
+
     it('creates a new user', async () => {
 
         const config = getOptions({

--- a/test/index.js
+++ b/test/index.js
@@ -125,7 +125,7 @@ describe('Tandy', () => {
         }
     });
 
-    it('replaces prefix if found at the start of the given route\'s path', async () => {
+    it('ignores the given prefix if not an exact match at the start of the route path', async () => {
 
         const config = getOptions({
             schwifty: {
@@ -168,7 +168,7 @@ describe('Tandy', () => {
         }
     });
 
-    it('strips the given prefix only if an exact match at the start of the route path', async () => {
+    it('replaces prefix if found at the start of the given route\'s path', async () => {
 
         const config = getOptions({
             schwifty: {


### PR DESCRIPTION
Heyo! I may have misunderstood what I was doing here :) But I was intending to address the following

- tandy would accept undefined values for its prefix, which would cause the asserting in `removePrefixFromPath` to throw, given that it's expecting the value to be a string
    - though I _think_ this cropped up in the last patch, from removing lodash, given how lodash.merge ignores null / undefined values in source, where Hoek applies them. so could opt to revise the Hoek merge method (applyToDefaults maybe?) instead if that feels better

- tandy will use prefix values that hapi considers invalid, which itself doesn't cause a problem, but becomes problematic due to the next issue

- tandy replaces the prefix value by length, not by match, so if tandy were to receive a prefix hapi would consider invalid e.g. `cone` no leading slash, tandy would turn `/prefix/cone` into `fix/cone`, which would cause haute to throw (I think...) 

Again, could be super confused here, ignorant of the project's history, but my hope was that these changes would help tandy work more predictably and in-step with hapi's method for prefixing routes? 

My bad if the code's as confused as the words 👍 🙏 thanks again for all the hard work here

Related somewhat to this tweak for user-pal: https://github.com/mattboutet/user-pal/pull/6 A more concrete example, I hope!
