### PR TITLE
Fix skip parameter type

### DIFF
--- a/lib/action-util.js
+++ b/lib/action-util.js
@@ -119,7 +119,17 @@ module.exports = (request, options) => {
         parseSkip: () => {
 
             const DEFAULT_SKIP = 0;
-            const skip = request.query.skip || (typeof options.skip !== 'undefined' ? options.skip : DEFAULT_SKIP);
+            let skip;
+
+            if (request.query.skip) {
+                skip = Math.abs(request.query.skip);
+            }
+            else if (typeof options.limit !== 'undefined') {
+                skip = options.skip;
+            }
+            else {
+                skip = DEFAULT_SKIP;
+            }
 
             return skip;
         },

--- a/lib/action-util.js
+++ b/lib/action-util.js
@@ -124,7 +124,7 @@ module.exports = (request, options) => {
             if (request.query.skip) {
                 skip = Math.abs(request.query.skip);
             }
-            else if (typeof options.limit !== 'undefined') {
+            else if (typeof options.skip !== 'undefined') {
                 skip = options.skip;
             }
             else {


### PR DESCRIPTION
When we use the "skip" parameter, the plugin use it as it is, a string. Causing database query error :
`select `Users`.* from `Users` limit 30 offset '30';`
should be : 
`select `Users`.* from `Users` limit 30 offset 30;`