### PR TITLE
Having skip in tandy config and query param overloads this test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandy",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Auto-generated, RESTful, CRUDdy route handlers for Schwifty models in hapi",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1558,7 +1558,7 @@ describe('Tandy', () => {
                     }
                 }
             },
-            handler: { tandy: { skip: 1 } }
+            handler: { tandy: {} }
         });
 
         const options = {


### PR DESCRIPTION
 It should just use query param in this case to ensure we're exercising the right bit of code.  I noticed this when debugging the bug with `skip` query params being handled as strings in the generated query, which doesn't work on MySQL.