### PR TITLE
Add missing WHERE clause to filter records at  /modelIdentity

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ These options allow you to act on behalf of the authenticated user.  Typically t
 
     Sets default sorting criteria (i.e. `createdDate ASC`) (overridden by `sort` query parameter).  Defaults to no sort applied.
 
+ - `where` (string). Applies to `find`.
+
+    Extracts only those records that fulfill a specified condition. (i.e. `createdDate = '2019-08-19'`)(overridden by `where` query parameter). 
+
 ## Usage
 Here's an (over)simplified example.
 

--- a/lib/action-util.js
+++ b/lib/action-util.js
@@ -93,6 +93,15 @@ module.exports = (request, options) => {
          * @param  {Request} request
          * @param  {Object} options
          */
+        parseWhere: () => {
+
+            return request.query.where || options.where || undefined;
+        },
+
+        /**
+         * @param  {Request} request
+         * @param  {Object} options
+         */
         parseLimit: () => {
 
             const DEFAULT_LIMIT = 30;

--- a/lib/action-util.js
+++ b/lib/action-util.js
@@ -95,7 +95,12 @@ module.exports = (request, options) => {
          */
         parseWhere: () => {
 
-            return request.query.where || options.where || undefined;
+            let queryWhere;
+            if ( request.query.where ) {
+                queryWhere = JSON.parse(request.query.where );
+            }
+
+            return queryWhere || options.where || undefined;
         },
 
         /**

--- a/lib/actions/find.js
+++ b/lib/actions/find.js
@@ -37,10 +37,12 @@ module.exports = function findRecords(route, options) {
         const sort = actionUtil.parseSort();
         const rangeStart = actionUtil.parseSkip();
         const rangeEnd = rangeStart ? rangeStart + limit : limit;
+        const where = actionUtil.parseWhere();
 
         const foundModels = await Model.query()
             .skipUndefined()
             .range(rangeStart, rangeEnd)
+            .where(where)
             .limit(limit)
             .orderByRaw(sort);
         return foundModels.results;

--- a/test/index.js
+++ b/test/index.js
@@ -1379,6 +1379,85 @@ describe('Tandy', () => {
         //this one's ID would cause it to be in a different spot if sort failed
         expect(result[2].email).to.equal('c@d.e');
     });
+    it('Exctracts users by firstName = a using options' , async () => {
+
+        const config = getOptions({
+            schwifty: {
+                models: [
+                    TestModels.Users
+                ]
+            }
+        });
+
+        const server = await getServer(config);
+        await server.initialize();
+
+        const knex = server.knex();
+        await knex.seed.run({ directory: 'test/seeds' });
+
+        server.route({
+            method: 'GET',
+            path: '/users',
+            handler: { tandy: { where: { firstName: 'a'  } } }
+        });
+
+        const options = {
+            method: 'GET',
+            url: '/users'
+        };
+
+        const response = await server.inject(options);
+        const result = response.result;
+
+        expect(response.statusCode).to.equal(200);
+        expect(result).to.be.an.array();
+        expect(result.length).to.equal(2);
+        expect(result[0]).to.be.an.object();
+        expect(result[0].firstName).to.equal('a');
+    });
+    it('Exctracts users by firstName = a using query param' , async () => {
+
+        const config = getOptions({
+            schwifty: {
+                models: [
+                    TestModels.Users
+                ]
+            }
+        });
+
+        const server = await getServer(config);
+        await server.initialize();
+
+        const knex = server.knex();
+        await knex.seed.run({ directory: 'test/seeds' });
+
+        server.route({
+            method: 'GET',
+            path: '/users',
+            handler: { tandy: {  } },
+            config: {
+                validate: {
+                    query: {
+                        where:Joi.string().required()
+                    }
+                }
+            }
+        });
+
+        const options = {
+            method: 'GET',
+            url: '/users?where=%7B%20%22firstName%22%3A%20%22a%22%20%7D'
+        };
+
+        const response = await server.inject(options);
+        const result = response.result;
+
+        expect(response.statusCode).to.equal(200);
+        expect(result).to.be.an.array();
+        expect(result.length).to.equal(2);
+        expect(result[0]).to.be.an.object();
+        expect(result[0].firstName).to.equal('a');
+    });
     it('Fetches limited number of users', async () => {
 
         const config = getOptions({


### PR DESCRIPTION
Now we can filter records by using where options object or query param.
`
{ 
    method: 'GET',
    path: '/turnos',
    handler: {
        tandy: { 
            limit: 10 ,
            where: { idStatus: 2 }
        }
    },
}`