### PR TITLE
Update dependencies, remove deprecated skipUndefined() objection functionality

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
-  "extends": "@hapi/eslint-config-hapi",
+  "extends": "plugin:@hapi/module",
   "parserOptions": {
-      "ecmaVersion": 9
+    "ecmaVersion": 2020,
+    "sourceType": "script"
   }
 }

--- a/lib/actions/find.js
+++ b/lib/actions/find.js
@@ -39,12 +39,19 @@ module.exports = function findRecords(route, options) {
         const rangeEnd = rangeStart ? rangeStart + limit : limit;
         const where = actionUtil.parseWhere();
 
-        const foundModels = await Model.query()
-            .skipUndefined()
-            .range(rangeStart, rangeEnd)
-            .where(where)
-            .limit(limit)
-            .orderByRaw(sort);
+        const foundModelsQuery = Model.query().range(rangeStart, rangeEnd).limit(limit);
+
+        if (where) {
+            foundModelsQuery.where(where);
+        }
+
+        if (sort) {
+            foundModelsQuery.orderByRaw(sort);
+        }
+
+        const foundModels = await foundModelsQuery;
+
         return foundModels.results;
+
     };
 };

--- a/lib/actions/populate.js
+++ b/lib/actions/populate.js
@@ -37,22 +37,28 @@ module.exports = function expand(route, options) {
         const rangeStart = actionUtil.parseSkip();
         const rangeEnd = rangeStart + limit;
 
-        const modelFull = await Model.query().skipUndefined().findById(keys.parent.value).withGraphFetched(relation)
+        const modelFullQuery = Model.query().findById(keys.parent.value)
+            .withGraphFetched(relation)
             .modifyGraph(relation, (builder) => {
 
-                builder.skipUndefined()
-                    .where(Ref(RelationModel.tableName + '.' + keys.child.key), '=', keys.child.value)
-                    .range(rangeStart, rangeEnd)
-                    .limit(limit)
-                    .orderByRaw(sort);
+                if (keys.child?.value) {
+                    builder.where(Ref(RelationModel.tableName + '.' + keys.child.key), '=', keys.child.value);
+                }
+
+                builder.range(rangeStart, rangeEnd).limit(limit);
+
+                if (sort) {
+                    builder.orderByRaw(sort);
+                }
             });
 
+        const modelFull = await modelFullQuery;
 
         if (!modelFull) {
             return Boom.notFound('No record found with the specified id.');
         }
 
-        if (keys.child.value) {
+        if (keys.child?.value) {
             if (modelFull[options.associationAttr].length) {
                 return h.response().code(204);
             }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "url": "https://github.com/hapipal/tandy/issues"
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/call": "8.x.x",
-    "@hapi/hoek": "9.x.x",
+    "@hapi/boom": "10.x.x",
+    "@hapi/call": "9.x.x",
+    "@hapi/hoek": "11.x.x",
     "joi": "17.x.x",
     "lodash": "^4.17.21"
   },
@@ -39,15 +39,15 @@
     "@hapipal/schwifty": "6.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.x.x",
     "@hapi/eslint-config-hapi": "13.x.x",
     "@hapi/eslint-plugin-hapi": "4.x.x",
-    "@hapi/hapi": ">=20",
-    "@hapi/lab": "24.x.x",
+    "@hapi/hapi": ">=21",
+    "@hapi/lab": "25.x.x",
     "coveralls": "3.x.x",
-    "eslint": "7.x.x",
-    "knex": "0.95.4",
-    "objection": "2.x.x",
+    "eslint": "8.x.x",
+    "knex": "2.4.2",
+    "objection": "3.x.x",
     "@hapipal/schwifty": "6.x.x",
     "sqlite3": "5.x.x"
   },

--- a/package.json
+++ b/package.json
@@ -36,12 +36,11 @@
   },
   "peerDependencies": {
     "@hapi/hapi": ">=19 <22",
-    "@hapipal/schwifty": "^6.0.0"
+    "@hapipal/schwifty": "^6.2.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.3",
-    "@hapi/eslint-config-hapi": "^13.0.0",
-    "@hapi/eslint-plugin-hapi": "^4.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
     "@hapi/hapi": ">=19 <22",
     "@hapi/lab": "^25.1.2",
     "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,28 +28,28 @@
     "url": "https://github.com/hapipal/tandy/issues"
   },
   "dependencies": {
-    "@hapi/boom": "10.x.x",
-    "@hapi/call": "9.x.x",
-    "@hapi/hoek": "11.x.x",
-    "joi": "17.x.x",
+    "@hapi/boom": "^10.0.1",
+    "@hapi/call": "^9.0.1",
+    "@hapi/hoek": "^11.0.2",
+    "joi": "^17.7.1",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=19 <21",
-    "@hapipal/schwifty": "6.x.x"
+    "@hapi/hapi": ">=19 <22",
+    "@hapipal/schwifty": "^6.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "9.x.x",
-    "@hapi/eslint-config-hapi": "13.x.x",
-    "@hapi/eslint-plugin-hapi": "4.x.x",
-    "@hapi/hapi": ">=21",
-    "@hapi/lab": "25.x.x",
-    "coveralls": "3.x.x",
-    "eslint": "8.x.x",
-    "knex": "2.4.2",
-    "objection": "3.x.x",
-    "@hapipal/schwifty": "6.x.x",
-    "sqlite3": "5.x.x"
+    "@hapi/code": "^9.0.3",
+    "@hapi/eslint-config-hapi": "^13.0.0",
+    "@hapi/eslint-plugin-hapi": "^4.0.0",
+    "@hapi/hapi": ">=19 <22",
+    "@hapi/lab": "^25.1.2",
+    "coveralls": "^3.1.1",
+    "eslint": "^8.34.0",
+    "knex": "^2.4.2",
+    "objection": "^3.0.1",
+    "@hapipal/schwifty": "^6.2.0",
+    "sqlite3": "^5.1.4"
   },
   "homepage": "https://github.com/hapipal/tandy"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hapipal/tandy",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Auto-generated, RESTful, CRUDdy route handlers for Schwifty models in hapi",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1388,6 +1388,41 @@ describe('Tandy', () => {
         expect(result.tokens).to.be.an.array();
         expect(result.tokens.length).to.equal(1);
     });
+
+    it('Fetches tokens for a user, sorted by token id', async () => {
+
+        const server = await getServer(getOptions());
+        server.registerModel([
+            TestModels.Users,
+            TestModels.Tokens
+        ]);
+
+        await server.initialize();
+
+        const knex = server.knex();
+        await knex.seed.run({ directory: 'test/seeds' });
+
+        server.route({
+            method: 'GET',
+            path: '/users/{id}/tokens',
+            handler: { tandy: { sort: 'Tokens.temp DESC' } }
+        });
+
+        const options = {
+            method: 'GET',
+            url: '/users/1/tokens'
+        };
+
+        const response = await server.inject(options);
+
+        const result = response.result;
+
+        expect(response.statusCode).to.equal(200);
+        expect(result.tokens).to.be.an.array();
+        expect(result.tokens.length).to.equal(2);
+        expect(result.tokens[0].temp).to.equal('text');
+    });
+
     it('Fetches limited number of tokens for a user using query param', async () => {
 
         const server = await getServer(getOptions());


### PR DESCRIPTION
Breaking out query parts after removing skipUndefined() exposed a testing hole, so this adds a new test as well.